### PR TITLE
Ignore case for black/white lists

### DIFF
--- a/genericadmin/admin.py
+++ b/genericadmin/admin.py
@@ -37,6 +37,9 @@ class BaseGenericModelAdmin(object):
             media = []
         media.append(JS_PATH + 'genericadmin.js')
         self.Media.js = tuple(media)
+        
+        self.content_type_whitelist = [s.lower() for s in self.content_type_whitelist]
+        self.content_type_blacklist = [s.lower() for s in self.content_type_blacklist]        
             
         super(BaseGenericModelAdmin, self).__init__(model, admin_site)
 


### PR DESCRIPTION
When setting 'content_type_whitelist' for example, the string has to be lower-cased in order for django-genericadmin to figure out to model. This will lower case the items in the list for the user, allowing the code to run as it should without case-sensitivity.