### PR TITLE
Support mixing generic and non generic inlines

### DIFF
--- a/genericadmin/admin.py
+++ b/genericadmin/admin.py
@@ -67,9 +67,10 @@ class BaseGenericModelAdmin(object):
                     
         if hasattr(self, 'inlines') and len(self.inlines) > 0:
             for FormSet, inline in zip(self.get_formsets(request), self.get_inline_instances(request)):
-                prefix = FormSet.get_default_prefix()
-                field_list = field_list + inline.get_generic_field_list(request, prefix)
-        
+                if hasattr(inline, 'get_generic_field_list'):
+                    prefix = FormSet.get_default_prefix()
+                    field_list = field_list + inline.get_generic_field_list(request, prefix)
+
         return field_list
 
     def get_urls(self):


### PR DESCRIPTION
Allows a GenericAdminModelAdmin to use both generic inlines and standard inlines.